### PR TITLE
Fix spelling and casing in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Coravel
 
 [![CircleCI](https://circleci.com/gh/jamesmh/coravel/tree/master.svg?style=svg)](https://circleci.com/gh/jamesmh/coravel/tree/master)
-[![BuitlWithDot.Net shield](https://builtwithdot.net/project/32/coravel/badge)](https://builtwithdot.net/project/32/coravel)
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/32/coravel/badge)](https://builtwithdot.net/project/32/coravel)
 ![Nuget](https://img.shields.io/nuget/v/Coravel.svg)
 ![NuGet](https://img.shields.io/nuget/dt/Coravel.svg)
 
 
-Coravel allows you to build .Net Core apps using a simple, expressive and straightforward syntax that lets you focus on **your app**.
+Coravel allows you to build .NET Core apps using a simple, expressive and straightforward syntax that lets you focus on **your app**.
 
 Let Coravel tackle the configuration and infrastructural details for you - and **build your app**!
 
@@ -30,17 +30,17 @@ Let Coravel tackle the configuration and infrastructural details for you - and *
 - [Caching](./Docs/Caching.md)
 - [Mailing](./Docs/Mailing.md)
 - [Invocables](./Docs/Invocables.md)
-- [Coravel-Cli](./Docs/Cli.md)
+- [Coravel CLI](./Docs/Cli.md)
 
 ## Requirements
 
-Coravel is a .Net Core library. You must be including Coravel in an existing .Net Core application (version 2.1.0 +).
+Coravel is a .NET Core library. You must be including Coravel in an existing .NET Core application (version 2.1.0+).
 
-### Coravel-Cli
+### Coravel CLI
 
-Use the [Coravel Cli](./Docs/Cli.md) to get started!
+Use the [Coravel CLI](./Docs/Cli.md) to get started!
 
-Coravel Cli is a dotnet core tool that you can use as a global executable (similar to `npm` or `dotnet` etc.) that gives you easy installs, scaffolding abilities, etc.
+Coravel CLI is a dotnet core tool that you can use as a global executable (similar to `npm` or `dotnet` etc.) that gives you easy installs, scaffolding abilities, etc.
 
 Install the tool:
 


### PR DESCRIPTION
Just a few minor corrections to spelling and casing. Note that the best way to deal with acronyms in software is to use the uppercase acronym in the name of it, but use PascalCase/camelCase (depending on programming language) for code. For example, the namespace for **Coravel CLI** would be `Coravel.Cli`. Especially with proper names like the development platform **.NET Core**.

With **BuiltWithDot.Net**, they're not using the capitalized "NET", so their product name takes precedance and should be referred to as such, so I didn't change it.