### PR TITLE
Fixed unit tests for non-us region

### DIFF
--- a/Src/UnitTests/Scheduling/CronTests/CronExpressionTests.cs
+++ b/Src/UnitTests/Scheduling/CronTests/CronExpressionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Coravel.Scheduling.Schedule.Cron;
 using Xunit;
 
@@ -123,7 +124,7 @@ namespace UnitTests.Scheduling.CronTests
         public void InvokeCron(string cronExpression, string dateString, bool shouldBeDue)
         {
             var expression = new CronExpression(cronExpression);
-            var time = DateTime.Parse(dateString);
+            var time = DateTime.ParseExact(dateString, "M/d/yyyy h:mm tt", CultureInfo.InvariantCulture);
             var isDue = expression.IsDue(time);
             Assert.Equal(shouldBeDue, isDue);
         }

--- a/Src/UnitTests/Scheduling/IntervalTests/SchedulerCronTests.cs
+++ b/Src/UnitTests/Scheduling/IntervalTests/SchedulerCronTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Coravel.Scheduling.Schedule;
 using Coravel.Scheduling.Schedule.Mutex;
@@ -131,7 +132,7 @@ namespace UnitTests.Scheduling.IntervalTests
 
             scheduler.Schedule(() => taskRan = true).Cron(cronExpression);
 
-            await scheduler.RunAtAsync(DateTime.Parse(dateString));
+            await scheduler.RunAtAsync(DateTime.ParseExact(dateString, "M/d/yyyy h:mm tt", CultureInfo.InvariantCulture));
 
             Assert.Equal(shouldRun, taskRan);
         }


### PR DESCRIPTION
Used `DateTime.ParseExact` so that these tests don't fail on computers set to non-us region.