### PR TITLE
Missing cache methods

### DIFF
--- a/Docs/Caching.md
+++ b/Docs/Caching.md
@@ -6,7 +6,7 @@ Coravel provides you with an easy to use API for caching in your .Net Core appli
 
 Coravel's cache is basically a wrapper for .Net Core's built-in caching. Coravel provides you with some extra features and a simpler syntax when doing typical/common caching operations.
 
-## Setup 
+## Setup
 
 Install Coravel, if not installed.
 
@@ -18,7 +18,7 @@ services.AddCache();
 
 This will enable in-memory (RAM) caching.
 
-Then, inject `ICache` (from `Coravel.Cache.Interfaces`) via dependency injection. 
+Then, inject `ICache` (from `Coravel.Cache.Interfaces`) via dependency injection.
 
 ```c#
 private ICache _cache;
@@ -35,17 +35,17 @@ Now, in your controller/injectable class, you may use Coravel's caching methods.
 
 ### Remember
 
-`Remember` will remember your cached item for the duration you specify. 
+`Remember` will remember your cached item for the duration you specify.
 
 `Remember` requires that you specify:
 - A cache key for this specific item
 - A method that returns the data you want cached (of any type)
-- A `TimeSpan` to indicate how long the item will be cached 
+- A `TimeSpan` to indicate how long the item will be cached
 
 For example:
 
 ```c#
-string BigDataLocalFunction() 
+string BigDataLocalFunction()
 {
     return "Some Big Data";
 };
@@ -53,7 +53,7 @@ string BigDataLocalFunction()
 this._cache.Remember("BigDataCacheKey", BigDataLocalFunction, TimeSpan.FromMinutes(10));
 ```
 
-Pretty simple? 
+Pretty simple?
 
 _P.S. It is always recommended that you not use hardcoded cache keys._
 
@@ -62,9 +62,9 @@ _P.S. It is always recommended that you not use hardcoded cache keys._
 It's `Remember`, but async:
 
 ```c#
-async SomeType BigDataLocalFunctionAsync() 
+async SomeType BigDataLocalFunctionAsync()
 {
-    // ... Doing some stuff ... 
+    // ... Doing some stuff ...
     return await SomeCostlyDbCall();
 };
 
@@ -87,6 +87,35 @@ It's `Forever`, but async:
 await this._cache.ForeverAsync("BigDataCacheKey", BigDataLocalFunctionAsync);
 ```
 
+### Get
+`Get` will return your stored items and will return null when your item doesn't exist.
+
+For example:
+```
+var storedValue = this._cache.Get<string>("BigDataCacheKey");
+```
+
+Optionally you can specify a value to return when your key doesn't exist.
+```
+var storedValue = this._cache.Get<string>("BigDataCacheKey", "There isn't a value");
+```
+### GetAsync
+It's `Get`, but async:
+```
+var storedValue = await this._cache.GetAsync<string>("BigDataCacheKey");
+```
+Or
+```
+var storedValue = await this._cache.GetAsync<string>("BigDataCacheKey", "There isn't a value");
+```
+
+### Has
+
+`Has` will check whether a key exists.
+```
+var exists = this._cache.Has("BigDataCacheKey");
+```
+
 ### Flush
 
 `Flush` will clear your entire cache.
@@ -105,7 +134,7 @@ this._cache.Forget("BigDataCacheKey");
 
 ## Extending Coravel With Custom Drivers
 
-If you wish, you can create your own cache driver that extends `Coravel.Cache.Interfaces.ICache`. Maybe you want to use Coravel but use a Redis store? 
+If you wish, you can create your own cache driver that extends `Coravel.Cache.Interfaces.ICache`. Maybe you want to use Coravel but use a Redis store?
 
 First, implement a class that extends the `ICache` interface.
 

--- a/Src/Coravel/Cache/InMemoryCache.cs
+++ b/Src/Coravel/Cache/InMemoryCache.cs
@@ -22,6 +22,35 @@ namespace Coravel.Cache
             this._keys = new HashSet<string>();
         }
 
+        public TResult Get<TResult>(string key)
+        {
+            return this.Get(key, default(TResult));
+        }
+
+        public TResult Get<TResult>(string key, TResult @default)
+        {
+            if (!this._cache.TryGetValue(key, out var value)) return @default;
+
+            if (value is TResult result) return result;
+
+            return @default;
+        }
+
+        public async Task<TResult> GetAsync<TResult>(string key)
+        {
+            return await this.GetAsync(key, default(TResult));
+        }
+
+        public async Task<TResult> GetAsync<TResult>(string key, TResult @default)
+        {
+            return this.Get(key, @default);
+        }
+
+        public bool Has(string key)
+        {
+            return this._keys.Contains(key);
+        }
+
         public TResult Remember<TResult>(string key, Func<TResult> cacheFunc, TimeSpan expiresIn)
         {
             this._keys.Add(key);

--- a/Src/Coravel/Cache/Interfaces/ICache.cs
+++ b/Src/Coravel/Cache/Interfaces/ICache.cs
@@ -6,6 +6,13 @@ namespace Coravel.Cache.Interfaces
 {
     public interface ICache
     {
+        TResult Get<TResult>(string key);
+        TResult Get<TResult>(string key, TResult @default);
+        Task<TResult> GetAsync<TResult>(string key);
+        Task<TResult> GetAsync<TResult>(string key, TResult @default);
+
+        bool Has(string key);
+
         TResult Remember<TResult>(string key, Func<TResult> cacheFunc, TimeSpan expiresIn);
         Task<TResult> RememberAsync<TResult>(string key, Func<Task<TResult>> cacheFunc, TimeSpan expiresIn);
 

--- a/Src/IntegrationTests/TestMvcApp/Controllers/CacheController.cs
+++ b/Src/IntegrationTests/TestMvcApp/Controllers/CacheController.cs
@@ -15,6 +15,33 @@ namespace TestMvcApp.Controllers
             this._cache = cache;
         }
 
+        public IActionResult Get()
+        {
+            const string key = "Get";
+            const string value = "72c41aad-7fec-4603-8f6c-be8a1335b477";
+            this._cache.Remember(key, () => value, TimeSpan.FromDays(1));
+            var result = this._cache.Get<string>(key);
+            return Content($"Was Cached:{(result == value).ToString()}");
+        }
+
+        public async Task<IActionResult> GetAsync()
+        {
+            const string key = "GetAsync";
+            const string value = "aec50a80-7b80-4a99-9617-a32aef61d3c7";
+            this._cache.Remember(key, () => value, TimeSpan.FromDays(1));
+            var result = await this._cache.GetAsync<string>(key);
+            return Content($"Was Cached:{(result == value).ToString()}");
+        }
+
+        public IActionResult Has()
+        {
+            const string key = "Has";
+            const string value = "72c41aad-7fec-4603-8f6c-be8a1335b477";
+            this._cache.Remember(key, () => value, TimeSpan.FromDays(1));
+            var result = this._cache.Has(key);
+            return Content($"Was Cached:{result.ToString()}");
+        }
+
         public IActionResult Remember()
         {
             bool wasCached = false;

--- a/Src/IntegrationTests/Tests/Cache/GetTests.cs
+++ b/Src/IntegrationTests/Tests/Cache/GetTests.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Tests.Cache
+{
+    public class GetTests : IClassFixture<WebApplicationFactory<TestMvcApp.Startup>>
+    {
+        private readonly WebApplicationFactory<TestMvcApp.Startup> _factory;
+
+        public GetTests(WebApplicationFactory<TestMvcApp.Startup> factory)
+        {
+            this._factory = factory;
+        }
+
+        [Fact]
+        public async Task Get_Cache_Working()
+        {
+            var client = _factory.CreateClient();
+
+            var response = await client.GetStringAsync("/Cache/Get");
+
+            Assert.Equal(Constants.WasCachedResult, response);
+        }
+
+        [Fact]
+        public async Task Get_Cache_Async_Working()
+        {
+            var client = _factory.CreateClient();
+
+            var response = await client.GetStringAsync("/Cache/GetAsync");
+
+            Assert.Equal(Constants.WasCachedResult, response);
+        }
+    }
+}

--- a/Src/IntegrationTests/Tests/Cache/HasTests.cs
+++ b/Src/IntegrationTests/Tests/Cache/HasTests.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Tests.Cache
+{
+    public class HasTests : IClassFixture<WebApplicationFactory<TestMvcApp.Startup>>
+    {
+        private readonly WebApplicationFactory<TestMvcApp.Startup> _factory;
+
+        public HasTests(WebApplicationFactory<TestMvcApp.Startup> factory)
+        {
+            this._factory = factory;
+        }
+
+        [Fact]
+        public async Task Has_Cache_Working()
+        {
+            var client = _factory.CreateClient();
+
+            var response = await client.GetStringAsync("/Cache/Has");
+
+            Assert.Equal(Constants.WasCachedResult, response);
+        }
+    }
+}


### PR DESCRIPTION
Adding `Get`, `GetAsync` and `Has` methods to ICache interface. As well as updating `InMemoryCache` to use them.

Addresses issue #54 
