### PR TITLE
Fixed typo in the mailing documentation

### DIFF
--- a/Docs/Mailing.md
+++ b/Docs/Mailing.md
@@ -139,7 +139,7 @@ namespace App.Mailables
     {
         private UserModel _user;
 
-        public NewUserViewMail(UserModel user) => this._user = user;
+        public NewUserViewMailable(UserModel user) => this._user = user;
 
         public override void Build()
         {


### PR DESCRIPTION
The original version uses another name as constructor than the class itself.