### PR TITLE
Support for cancellable invocables

### DIFF
--- a/Src/Coravel/Invocable/ICancellableInvocable.cs
+++ b/Src/Coravel/Invocable/ICancellableInvocable.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading;
+
+namespace Coravel.Invocable
+{
+    public interface ICancellableInvocable
+    {
+        CancellationToken CancellationToken { get; set; }
+    }
+}

--- a/Src/Coravel/Scheduling/HostedService/SchedulerHost.cs
+++ b/Src/Coravel/Scheduling/HostedService/SchedulerHost.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -43,6 +41,8 @@ namespace Coravel.Scheduling.HostedService
         {
             this._schedulerEnabled = false; // Prevents changing the timer from firing scheduled tasks.
             this._timer?.Change(Timeout.Infinite, 0);
+
+            this._scheduler.CancelAllCancellableTasks();
 
             // If a previous scheduler execution is still running (due to some long-running scheduled task[s])
             // we don't want to shutdown while they are still running.

--- a/Src/Coravel/Scheduling/Schedule/Event/ScheduledEvent.cs
+++ b/Src/Coravel/Scheduling/Schedule/Event/ScheduledEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Coravel.Invocable;
 using Coravel.Scheduling.Schedule.Cron;
@@ -80,7 +81,7 @@ namespace Coravel.Scheduling.Schedule.Event
             }
         }
 
-        public async Task InvokeScheduledEvent()
+        public async Task InvokeScheduledEvent(CancellationToken cancellationToken)
         {
             if (await WhenPredicateFails())
             {
@@ -99,6 +100,11 @@ namespace Coravel.Scheduling.Schedule.Event
                 {
                     if (GetInvocable(scope.ServiceProvider) is IInvocable invocable)
                     {
+                        if (invocable is ICancellableInvocable cancellableInvokable)
+                        {
+                            cancellableInvokable.CancellationToken = cancellationToken;
+                        }
+
                         await invocable.Invoke();
                     }
                 }

--- a/Src/UnitTests/CoravelUnitTests/Scheduling/Invocable/CancellableInvocableTests.cs
+++ b/Src/UnitTests/CoravelUnitTests/Scheduling/Invocable/CancellableInvocableTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Coravel.Invocable;
+using Coravel.Scheduling.Schedule;
+using Coravel.Scheduling.Schedule.Mutex;
+using Microsoft.Extensions.DependencyInjection;
+using UnitTests.Scheduling.Stubs;
+using Xunit;
+
+namespace CoravelUnitTests.Scheduling.Invocable
+{
+    public class CancellableInvocableTests
+    {
+
+        [Fact]
+        public async Task TestInvocableCanBeCancelled()
+        {
+            bool invocableCancelled = false;
+
+            var services = new ServiceCollection();
+            services.AddScoped<Action>(p => () => invocableCancelled = true);
+            services.AddScoped<CancellableInvocable>();
+            var provider = services.BuildServiceProvider();
+
+            var scheduler = new Scheduler(new InMemoryMutex(), provider.GetRequiredService<IServiceScopeFactory>(), new DispatcherStub());
+            
+            scheduler.Schedule<CancellableInvocable>().EveryMinute();
+
+            var schedulerTask = scheduler.RunAtAsync(new DateTime(2019, 1, 1));
+
+            scheduler.CancelAllCancellableTasks();
+
+            await schedulerTask;
+
+            Assert.True(invocableCancelled);
+        }
+
+
+        private class CancellableInvocable : IInvocable, ICancellableInvocable
+        {
+            public CancellationToken CancellationToken { get; set; }
+
+            private readonly Action _func;
+
+            public CancellableInvocable(Action func)
+            {
+                this._func = func;
+            }
+
+            public async Task Invoke()
+            {
+                while(!CancellationToken.IsCancellationRequested)
+                {
+                    await Task.Delay(50);
+                }
+
+                _func();
+            }
+        }
+    }
+}

--- a/Src/UnitTests/CoravelUnitTests/Scheduling/Invocable/CancellableInvocableTests.cs
+++ b/Src/UnitTests/CoravelUnitTests/Scheduling/Invocable/CancellableInvocableTests.cs
@@ -53,7 +53,7 @@ namespace CoravelUnitTests.Scheduling.Invocable
             public async Task Invoke()
             {
                 await Task.Delay(500, CancellationToken)
-                    .ContinueWith(task => _func(), TaskContinuationOptions.OnlyOnCanceled);
+                    .ContinueWith(task => this._func(), TaskContinuationOptions.OnlyOnCanceled);
             }
         }
     }

--- a/Src/UnitTests/CoravelUnitTests/Scheduling/Invocable/CancellableInvocableTests.cs
+++ b/Src/UnitTests/CoravelUnitTests/Scheduling/Invocable/CancellableInvocableTests.cs
@@ -52,12 +52,8 @@ namespace CoravelUnitTests.Scheduling.Invocable
 
             public async Task Invoke()
             {
-                while(!CancellationToken.IsCancellationRequested)
-                {
-                    await Task.Delay(50);
-                }
-
-                _func();
+                await Task.Delay(500, CancellationToken)
+                    .ContinueWith(task => _func(), TaskContinuationOptions.OnlyOnCanceled);
             }
         }
     }


### PR DESCRIPTION
Thank you for your contribution!
Before submitting this PR, please make sure:

- [x] If you are fixing something **other than a typo**, **please always create an issue first**. 
      Otherwise, your PR will probably be rejected
- [x] Your addition is not too large. The more files/lOC changed means the longer it'll take to be addressed by me (the maintainer)
- [x] Your code builds clean without any errors or warnings
- [ ] You have added user documentation for any additional features
- [x] You have added unit tests which (a) pass and (b) sufficiently cover your changes

Other Notes:

Coravel is created with a specific vision and philosophy:

- Simple, fluent and straightforward public APIs
- Easy to read documentation that guides users coherently
- Building **useful** features because they really are useful - not just for the sake of adding "more features"

To that effect, don't feel bad when many changes are asked of your PR 😉

___ 

Implementation for #133 

As far as I can tell, the cancellation token passed to `IHostedService.StartAsync` is only used to cancel the startup process and does not get triggered on shutdown. Instead I created one in the scheduler and trigger the cancellation manually on shutdown before waiting for all the tasks to finish.

I haven't tackled updating the documentation yet. Let me know if you'd like me to or if you'll write it up yourself.