### PR TITLE
Run a schedule once a day, at a random time

### DIFF
--- a/Src/Coravel/Scheduling/Schedule/Event/ScheduledEvent.cs
+++ b/Src/Coravel/Scheduling/Schedule/Event/ScheduledEvent.cs
@@ -136,6 +136,17 @@ namespace Coravel.Scheduling.Schedule.Event
             this._expression = new CronExpression("00 00 * * *");
             return this;
         }
+        
+        public IScheduledEventConfiguration DailyAtRandomTime()
+        {
+            var hour = new Random();
+            var minute = new Random();
+
+            var randomMinute = minute.Next(0,59);
+            var randomHour = hour.Next(0,23);
+            _expression = new CronExpression($"{randomMinute:##} {randomHour:##} * * *");
+            return this;
+        }        
 
         public IScheduledEventConfiguration DailyAtHour(int hour)
         {

--- a/Src/Coravel/Scheduling/Schedule/Interfaces/IScheduleInterval.cs
+++ b/Src/Coravel/Scheduling/Schedule/Interfaces/IScheduleInterval.cs
@@ -60,6 +60,12 @@ namespace Coravel.Scheduling.Schedule.Interfaces
         IScheduledEventConfiguration Daily();
 
         /// <summary>
+        /// Scheduled task runs once a day at a random time.
+        /// </summary>
+        /// <returns></returns>
+        IScheduledEventConfiguration DailyAtRandomTime();        
+        
+        /// <summary>
         /// Scheduled task runs once a day at the hour specified.
         /// </summary>
         /// <example>

--- a/Src/UnitTests/CoravelUnitTests/Scheduling/IntervalTests/SchedulerDailyAtRandomTimeTests.cs
+++ b/Src/UnitTests/CoravelUnitTests/Scheduling/IntervalTests/SchedulerDailyAtRandomTimeTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using Coravel.Scheduling.Schedule;
+using Coravel.Scheduling.Schedule.Mutex;
+using UnitTests.Scheduling.Stubs;
+using Xunit;
+using static UnitTests.Scheduling.Helpers.SchedulingTestHelpers;
+
+namespace UnitTests.Scheduling.IntervalTests
+{
+    public class SchedulerDailyAtRandomTimeTests
+    {
+        [Theory]
+        // Should run
+        [InlineData(1, 0, 1, false)]
+        [InlineData(2, 0, 1, false)]
+        [InlineData(3, 0, 1, false)]
+        [InlineData(3, 1, 1, false)]
+        [InlineData(3, 2, 1, false)]
+        [InlineData(1, 4, 1, false)]
+        [InlineData(2, 5, 1, false)]
+        [InlineData(10, 6, 1, false)]
+        [InlineData(23, 7, 1, false)]
+        [InlineData(33, 8, 1, false)]
+        [InlineData(30, 12, 1, false)]
+        [InlineData(45, 13, 1, false)]
+        [InlineData(50, 15, 1, false)]
+        [InlineData(59, 23, 1, false)]
+        public async Task ValidDaily(int day, int hour, int minute, bool shouldRun)
+        {
+            var scheduler = new Scheduler(new InMemoryMutex(), new ServiceScopeFactoryStub(), new DispatcherStub());
+            bool taskRan = false;
+
+            scheduler.Schedule(() => taskRan = true).DailyAtRandomTime();
+
+            await RunScheduledTasksFromDayHourMinutes(scheduler, day, hour, minute);
+
+            Assert.Equal(shouldRun, taskRan);
+        }
+    }
+}

--- a/Src/UnitTests/CoravelUnitTests/Scheduling/IntervalTests/SchedulerHourlyTests.cs
+++ b/Src/UnitTests/CoravelUnitTests/Scheduling/IntervalTests/SchedulerHourlyTests.cs
@@ -10,7 +10,6 @@ namespace UnitTests.Scheduling.IntervalTests
 {
     public class SchedulerHourlyTests
     {
-        [Theory]
         // Should run
         [InlineData(0, 0, 0, true)]
         [InlineData(1, 4, 0, true)]


### PR DESCRIPTION
The aim for this change is that the schedule should run once a day, but not always at the same time.  This use case would help for load balanced scenarios. I.e. we have 3 services running on 3 different machines.  All the services have the same config.  However with this change, we would have the services running their schedules at different times of the day (without needing to add additional configuration).

Thank you for your contribution!
Before submitting this PR, please consider:

- If you are fixing something **other than a typo, please always create an issue first**. Otherwise, your PR will probably be rejected.
- You have added unit tests which (a) pass and (b) sufficiently cover your changes
