### PR TITLE
Add missing parameter to custom mailer function example.

### DIFF
--- a/DocsV2/docs/Mailing/README.md
+++ b/DocsV2/docs/Mailing/README.md
@@ -101,7 +101,8 @@ async Task SendMailCustomAsync(
     MailRecipient from,
     MailRecipient replyTo,
     IEnumerable<MailRecipient> cc,
-    IEnumerable<MailRecipient> bcc
+    IEnumerable<MailRecipient> bcc,
+    IEnumerable<Attachment> attachments = null
 )
 {
     // Custom logic for sending an email.


### PR DESCRIPTION
The example custom mailer function didn't follow the [`SendAsyncFunc` delegate signature](https://github.com/jamesmh/coravel/blob/ee3f88ebdf6328f149da04e80bce0eb85c830d25/Src/Coravel.Mailer/Mail/Mailers/CustomMailer.cs#L10).
