### PR TITLE
fix: Add MIT license for published NuGet packages

### DIFF
--- a/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/Coravel.Cache.Database.Core.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/Coravel.Cache.Database.Core.csproj
@@ -3,11 +3,12 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Coravel.Cache.Database.Core</PackageId>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel Database Cache Driver Shared Library</Title>
     <Description>Core tools for Coravel database cache drivers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jamesmh/coravel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jamesmh/coravel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Src/Coravel.Cache.Database/Coravel.Cache.PostgreSQL/Coravel.Cache.PostgreSQL.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.PostgreSQL/Coravel.Cache.PostgreSQL.csproj
@@ -8,11 +8,12 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Coravel.Cache.PostgreSQL</PackageId>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel PostgreSQL Cache Driver</Title>
     <Description>Distributed MS PostgreSQL cache driver for Coravel</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jamesmh/coravel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jamesmh/coravel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Src/Coravel.Cache.Database/Coravel.Cache.SqlServer/Coravel.Cache.SqlServer.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.SqlServer/Coravel.Cache.SqlServer.csproj
@@ -7,11 +7,12 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Coravel.Cache.SQLServer</PackageId>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel SQL Server Cache Driver</Title>
     <Description>Distributed MS SQL Server cache driver for Coravel</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jamesmh/coravel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jamesmh/coravel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Src/Coravel.Cli/Coravel.Cli.csproj
+++ b/Src/Coravel.Cli/Coravel.Cli.csproj
@@ -8,8 +8,9 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <ToolCommandName>coravel</ToolCommandName>
     <PackageId>coravel-cli</PackageId>
-    <PackageVersion>0.10.0</PackageVersion>
+    <PackageVersion>0.10.1</PackageVersion>
     <AssemblyName>Coravel.Cli</AssemblyName>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jamesmh/coravel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jamesmh/coravel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Src/Coravel.Mailer/Coravel.Mailer.csproj
+++ b/Src/Coravel.Mailer/Coravel.Mailer.csproj
@@ -5,11 +5,12 @@
     <AddRazorSupportForMvc>True</AddRazorSupportForMvc>
 
     <PackageId>Coravel.Mailer</PackageId>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel.Mailer</Title>
     <Description>Coravel's Mailer feature. Provides a terse yet expressive syntax with tools to send mail in your .NET Core apps.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jamesmh/coravel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jamesmh/coravel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Src/Coravel/Coravel.csproj
+++ b/Src/Coravel/Coravel.csproj
@@ -2,11 +2,12 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Coravel</PackageId>
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel</Title>
     <Description>Near-zero config .NET Core library that makes Task Scheduling, Caching, Queuing, Mailing, Event Broadcasting (and more) a breeze!</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jamesmh/coravel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jamesmh/coravel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Related to #281: 

- Added the MIT license to all packaged projects.
   - This shall allow users to see the license on nuget.org, under the _About_ section.
   - This shall allow the Synopsys Detect (i.e. Blackduck) tool to find the license information and no longer flag this as a risk regarding licensing.
- Bumped all projects to the next available patch version.
