### PR TITLE
fix/docs: Generate XML documentation for NuGet packages

### DIFF
--- a/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/Coravel.Cache.Database.Core.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/Coravel.Cache.Database.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Coravel.Cache.Database.Core</PackageId>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel Database Cache Driver Shared Library</Title>
@@ -14,6 +14,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>netcore;coravel;caching;database</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Coravel.Cache.Database/Coravel.Cache.PostgreSQL/Coravel.Cache.PostgreSQL.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.PostgreSQL/Coravel.Cache.PostgreSQL.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Coravel.Cache.PostgreSQL</PackageId>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel PostgreSQL Cache Driver</Title>
@@ -19,6 +19,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>netcore;coravel;caching;postgresql</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/Src/Coravel.Cache.Database/Coravel.Cache.SqlServer/Coravel.Cache.SqlServer.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.SqlServer/Coravel.Cache.SqlServer.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Coravel.Cache.SQLServer</PackageId>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel SQL Server Cache Driver</Title>
@@ -18,6 +18,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>netcore;coravel;caching;sqlserver</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/Src/Coravel.Cli/Coravel.Cli.csproj
+++ b/Src/Coravel.Cli/Coravel.Cli.csproj
@@ -8,15 +8,16 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <ToolCommandName>coravel</ToolCommandName>
     <PackageId>coravel-cli</PackageId>
-    <PackageVersion>0.10.1</PackageVersion>
+    <PackageVersion>0.10.2</PackageVersion>
     <AssemblyName>Coravel.Cli</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/jamesmh/coravel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jamesmh/coravel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-
     <Authors>James Hickey</Authors>
     <Description>Cli for Coravel</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Coravel.Mailer/Coravel.Mailer.csproj
+++ b/Src/Coravel.Mailer/Coravel.Mailer.csproj
@@ -3,9 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>True</AddRazorSupportForMvc>
-
     <PackageId>Coravel.Mailer</PackageId>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel.Mailer</Title>
@@ -16,6 +15,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>netcore;coravel;mail;e-mail;email;mailer;mail template;e-mail template; email template</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Coravel.Mailer/MailServiceRegistration.cs
+++ b/Src/Coravel.Mailer/MailServiceRegistration.cs
@@ -36,6 +36,7 @@ namespace Coravel
         /// Useful for testing.
         /// </summary>
         /// <param name="services"></param>
+        /// <param name="config"></param>
         public static IServiceCollection AddFileLogMailer(this IServiceCollection services, IConfiguration config)
         {
             var globalFrom = GetGlobalFromRecipient(config);
@@ -83,6 +84,7 @@ namespace Coravel
         /// Register Coravel's mailer using the Custom Mailer.
         /// </summary>
         /// <param name="services"></param>
+        /// <param name="config"></param>
         /// <param name="sendMailAsync"></param>
         public static IServiceCollection AddCustomMailer(this IServiceCollection services, IConfiguration config, CustomMailer.SendAsyncFunc sendMailAsync)
         {

--- a/Src/Coravel/Coravel.csproj
+++ b/Src/Coravel/Coravel.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Coravel</PackageId>
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel</Title>
@@ -13,6 +13,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>netcore;scheduling;coravel;queuing;scheduler;framework</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.0" />

--- a/Src/Coravel/Queuing/Queue.cs
+++ b/Src/Coravel/Queuing/Queue.cs
@@ -149,7 +149,7 @@ namespace Coravel.Queuing
                 {
                     Type invocableType = typeof(T);
                     // This allows us to scope the scheduled IInvocable object
-                    /// and allow DI to inject it's dependencies.
+                    // and allow DI to inject it's dependencies.
                     using (var scope = this._scopeFactory.CreateScope())
                     {
                         if (scope.ServiceProvider.GetService(invocableType) is IInvocable invocable)

--- a/Src/Coravel/SchedulerServiceRegistration.cs
+++ b/Src/Coravel/SchedulerServiceRegistration.cs
@@ -17,7 +17,6 @@ namespace Coravel
         /// Register Coravel's Scheduler.
         /// </summary>
         /// <param name="services">Service collection</param>
-        /// <param name="assignScheduledTasks">Action that assigns all your scheduled tasks</param>
         /// <returns></returns>
         public static IServiceCollection AddScheduler(this IServiceCollection services)
         {

--- a/Src/Coravel/Scheduling/Schedule/Cron/CronExpressionComplexPart.cs
+++ b/Src/Coravel/Scheduling/Schedule/Cron/CronExpressionComplexPart.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Coravel.Scheduling.Schedule.Cron
 {
@@ -15,7 +14,7 @@ namespace Coravel.Scheduling.Schedule.Cron
         /// <summary>
         /// From the cron expression, get all the int values that are valid due times.
         /// </summary>
-        /// <param name="expression"></param>
+        /// <param name="time"></param>
         /// <returns></returns>
         public bool CheckIfTimeIsDue(int time)
         {
@@ -51,6 +50,7 @@ namespace Coravel.Scheduling.Schedule.Cron
         /// Get value from a cron expression with a single value.
         /// </summary>
         /// <param name="expression"></param>
+        /// <param name="toCheck"></param>
         /// <returns></returns>
         private static bool CheckIsSpecifiedInt(string expression, int toCheck)
         {

--- a/Src/Coravel/Scheduling/Schedule/Cron/CronExpressionPart.cs
+++ b/Src/Coravel/Scheduling/Schedule/Cron/CronExpressionPart.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using Coravel.Scheduling.Schedule.Helpers;
 
 namespace Coravel.Scheduling.Schedule.Cron
 {
@@ -25,7 +22,7 @@ namespace Coravel.Scheduling.Schedule.Cron
         /// <summary>
         /// Based on the cron expression, is this DateTime due?
         /// </summary>
-        /// <param name="dateTime"></param>
+        /// <param name="time"></param>
         /// <returns></returns>
         public bool IsDue(int time)
         {

--- a/Src/Coravel/Scheduling/Schedule/Event/ScheduledEvent.cs
+++ b/Src/Coravel/Scheduling/Schedule/Event/ScheduledEvent.cs
@@ -99,8 +99,8 @@ namespace Coravel.Scheduling.Schedule.Event
             }
             else
             {
-                /// This allows us to scope the scheduled IInvocable object
-                /// and allow DI to inject it's dependencies.
+                // This allows us to scope the scheduled IInvocable object
+                // and allow DI to inject it's dependencies.
                 using (var scope = this._scopeFactory.CreateScope())
                 {
                     if (GetInvocable(scope.ServiceProvider) is IInvocable invocable)


### PR DESCRIPTION
Fixes #265.

## Core changes
Updated all packaged projects so that they **generate XML documentation** with new patch versions.

## Miscellaneous changes
- Fixed some warnings regarding documentation.
- Removed unnecessary `using` statements.