### PR TITLE
Unique name queues

### DIFF
--- a/Src/Coravel/Queuing/Exceptions/QueueNotFoundException.cs
+++ b/Src/Coravel/Queuing/Exceptions/QueueNotFoundException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Coravel.Queuing.Exceptions
+{
+    public class QueueNotFoundException : Exception
+    {
+        public QueueNotFoundException(string name): base($"Queue with name '{name}' doesn't exist!")
+        {
+            
+        }
+    }
+}

--- a/Src/Coravel/Queuing/HostedService/QueuingHost.cs
+++ b/Src/Coravel/Queuing/HostedService/QueuingHost.cs
@@ -29,7 +29,10 @@ namespace Coravel.Queuing.HostedService
         public Task StartAsync(CancellationToken cancellationToken)
         {
             int consummationDelay = GetConsummationDelay();
-
+            if (!string.IsNullOrEmpty(_queue.QueueName))
+            {
+                _logger.LogDebug($"Coravel is starting queue service for '{_queue.QueueName}'");
+            }
             this._timer = new Timer((state) => this._signal.Release(), null, TimeSpan.Zero, TimeSpan.FromSeconds(consummationDelay));
             Task.Run(ConsumeQueueAsync);
             return Task.CompletedTask;
@@ -74,7 +77,14 @@ namespace Coravel.Queuing.HostedService
         public void Dispose()
         {
             this._timer?.Dispose();
-            this._logger.LogInformation("Coravel's Queuing service is now stopped.");
+            if (string.IsNullOrEmpty(_queue.QueueName))
+            {
+                this._logger.LogInformation("Coravel's Queuing service is now stopped.");
+            }
+            else
+            {
+                this._logger.LogInformation($"Coravel's Queuing service for '{_queue.QueueName}' is now stopped.");
+            }
         }
     }
 }

--- a/Src/Coravel/Queuing/Interfaces/IQueue.cs
+++ b/Src/Coravel/Queuing/Interfaces/IQueue.cs
@@ -12,6 +12,10 @@ namespace Coravel.Queuing.Interfaces
     public interface IQueue
     {
         /// <summary>
+        /// Contains a unique name for the queue!
+        /// </summary>
+        string QueueName { get; }
+        /// <summary>
         /// Queue a new synchronous task.
         /// </summary>
         /// <param name="workItem">The task to be invoke by Coravel.</param>

--- a/Src/Coravel/Queuing/Interfaces/IQueues.cs
+++ b/Src/Coravel/Queuing/Interfaces/IQueues.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+
+namespace Coravel.Queuing.Interfaces
+{
+    public interface IQueues
+    {
+        IQueue Get(string queueName);
+    }
+}

--- a/Src/Coravel/Queuing/Queue.cs
+++ b/Src/Coravel/Queuing/Queue.cs
@@ -16,6 +16,7 @@ namespace Coravel.Queuing
 {
     public class Queue : IQueue, IQueueConfiguration
     {
+        public string QueueName { get; private set; }
         private ConcurrentQueue<ActionOrAsyncFunc> _tasks = new ConcurrentQueue<ActionOrAsyncFunc>();
         private ConcurrentDictionary<Guid, CancellationTokenSource> _tokens = new ConcurrentDictionary<Guid, CancellationTokenSource>();
         private Action<Exception> _errorHandler;
@@ -28,6 +29,12 @@ namespace Coravel.Queuing
 
         public Queue(IServiceScopeFactory scopeFactory, IDispatcher dispatcher)
         {
+            this._scopeFactory = scopeFactory;
+            this._dispatcher = dispatcher;
+        }
+
+        public Queue(string queueName, IServiceScopeFactory scopeFactory, IDispatcher dispatcher) {
+            this.QueueName = queueName;
             this._scopeFactory = scopeFactory;
             this._dispatcher = dispatcher;
         }
@@ -115,7 +122,7 @@ namespace Coravel.Queuing
             }
         }
 
-        public async Task ConsumeQueueOnShutdown() 
+        public async Task ConsumeQueueOnShutdown()
         {
             this.CancelAllTokens();
             await this.ConsumeQueueAsync();
@@ -153,9 +160,9 @@ namespace Coravel.Queuing
                     using (var scope = this._scopeFactory.CreateScope())
                     {
                         if (scope.ServiceProvider.GetService(invocableType) is IInvocable invocable)
-                        {                            
+                        {
                             if(beforeInvoked != null)
-                            {                            
+                            {
                                 beforeInvoked(invocable);
                             }
 
@@ -180,7 +187,7 @@ namespace Coravel.Queuing
                 {
                     token.Dispose();
                 }
-            }                   
+            }
         }
 
         private List<ActionOrAsyncFunc> DequeueAllTasks()

--- a/Src/Coravel/Queuing/QueuesCollection.cs
+++ b/Src/Coravel/Queuing/QueuesCollection.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using Coravel.Queuing.Interfaces;
+using System.Linq;
+using Coravel.Queuing.Exceptions;
+
+namespace Coravel.Queuing
+{
+    public class QueuesCollection : IQueues
+    {
+        private readonly IEnumerable<IQueue> _queues;
+
+        public QueuesCollection(IEnumerable<IQueue> queues)
+        {
+            _queues = queues;
+        }
+        public IQueue Get(string queueName)
+        {
+            if (_queues.FirstOrDefault(x => x.QueueName == queueName) is IQueue queue)
+            {
+                return queue;
+            }
+            throw new QueueNotFoundException(queueName);
+        }
+    }
+}


### PR DESCRIPTION
The issue related to this PR is. https://github.com/jamesmh/coravel/issues/284

A new extension method is added to the ServicesCollection, `AddQueues`.
This method will get an action which has the `IServicesCollection` as the parameter so you can use `AddQueue` as you would do normally. 
Also it will inject `IQueues` into `DI` so you can query for the registered queues.

The ToDos in my opinion are as follow:
1. On `AddQueues` method it should NOT be possible that inside the action we can again call `AddQueues` . Maybe we can replace the IServicesCollection with `QueuesOption` and this class will provide the `AddQueue` method.
2. At the moment in Coravel it is configurable that how often the worker run the single queue but since we have now multiple queues I think this should also have a configuration in `appsettings.json`. If they specify the old config it would be apply for all but if they specify the name of the `queue` as the key and the value will be the delay inside `appsettings` we can adjust each queue.
3. The queue name at the moment is not really unique. On adding them to the `DI` we should check if the same name is already added or not and handle the error accordingly.