### PR TITLE
SMTPMailer adding ReplyTo in SMTP message header

### DIFF
--- a/Src/Coravel.Mailer/Coravel.Mailer.csproj
+++ b/Src/Coravel.Mailer/Coravel.Mailer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>.net6.0</TargetFramework>
     <AddRazorSupportForMvc>True</AddRazorSupportForMvc>
     <PackageId>Coravel.Mailer</PackageId>
     <Version>5.0.1</Version>

--- a/Src/Coravel.Mailer/Coravel.Mailer.csproj
+++ b/Src/Coravel.Mailer/Coravel.Mailer.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>.net6.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AddRazorSupportForMvc>True</AddRazorSupportForMvc>
     <PackageId>Coravel.Mailer</PackageId>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel.Mailer</Title>

--- a/Src/Coravel.Mailer/Coravel.Mailer.csproj
+++ b/Src/Coravel.Mailer/Coravel.Mailer.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>.net6.0</TargetFramework>
     <AddRazorSupportForMvc>True</AddRazorSupportForMvc>
     <PackageId>Coravel.Mailer</PackageId>
-    <Version>5.0.1</Version>
+    <Version>5.0.0</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel.Mailer</Title>

--- a/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
@@ -124,7 +124,7 @@ namespace Coravel.Mailer.Mail.Mailers
             mail.From.Add(AsMailboxAddress(this._globalFrom ?? @from));
         }
 
-        private static void SetReplyTo(MailRecipient replyTo,  MimeMessage mail)
+        private static void SetReplyTo(MailRecipient replyTo, MimeMessage mail)
         {
             mail.ReplyTo.Add(AsMailboxAddress(replyTo));
         }

--- a/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
@@ -120,7 +120,7 @@ namespace Coravel.Mailer.Mail.Mailers
             mail.From.Add(AsMailboxAddress(this._globalFrom ?? @from));
         }
 
-        private void SetReplyTo(MailRecipient replyTo,  MimeMessage mail)
+        private static void SetReplyTo(MailRecipient replyTo,  MimeMessage mail)
         {
             mail.ReplyTo.Add(AsMailboxAddress(replyTo));
         }

--- a/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
@@ -58,9 +58,11 @@ namespace Coravel.Mailer.Mail.Mailers
             SetRecipients(to, mail);
             SetCc(cc, mail);
             SetBcc(bcc, mail);
-            SetReplyTo(replyTo, mail);
             mail.Subject = subject;
             SetMailBody(message, attachments, mail);
+
+            if(replyTo != null)
+                SetReplyTo(replyTo, mail);
 
             using (var client = new SmtpClient())
             {

--- a/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
@@ -61,8 +61,10 @@ namespace Coravel.Mailer.Mail.Mailers
             mail.Subject = subject;
             SetMailBody(message, attachments, mail);
 
-            if(replyTo != null)
+            if (replyTo != null)
+            {
                 SetReplyTo(replyTo, mail);
+            }
 
             using (var client = new SmtpClient())
             {

--- a/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
@@ -58,6 +58,7 @@ namespace Coravel.Mailer.Mail.Mailers
             SetRecipients(to, mail);
             SetCc(cc, mail);
             SetBcc(bcc, mail);
+            SetReplyTo(replyTo, mail);
             mail.Subject = subject;
             SetMailBody(message, attachments, mail);
 
@@ -117,6 +118,11 @@ namespace Coravel.Mailer.Mail.Mailers
         private void SetFrom(MailRecipient @from, MimeMessage mail)
         {
             mail.From.Add(AsMailboxAddress(this._globalFrom ?? @from));
+        }
+
+        private void SetReplyTo(MailRecipient replyTo,  MimeMessage mail)
+        {
+            mail.ReplyTo.Add(AsMailboxAddress(replyTo));
         }
 
         private static MailboxAddress AsMailboxAddress(MailRecipient recipient) =>

--- a/Src/UnitTests/MailerUnitTests/Mail/SmtpMailerTests.cs
+++ b/Src/UnitTests/MailerUnitTests/Mail/SmtpMailerTests.cs
@@ -31,6 +31,24 @@ namespace UnitTests.Mail
         }
 
 
+        [Fact]
+        public async Task SmtpMailerRenderWithReplyToSucessful()
+        {
+            var renderer = RazorRendererFactory.MakeInstance(new ConfigurationBuilder().Build());
+            var mailer = new SmtpMailer(renderer, "dummy", 1, "dummy", "dummy");
+
+            string message = await mailer.RenderAsync(
+                new GenericHtmlMailable()
+                    .Subject("test")
+                    .From("from@test.com")
+                    .ReplyTo("replyto@test.com")
+                    .To("to@test.com")
+                    .Html("<html></html>")
+            );
+
+            Assert.Equal("<html></html>", message);
+        }
+
         [Theory]
         [InlineData("", "", false)]
         [InlineData(null, "", false)]


### PR DESCRIPTION
This is for issue #357. 

The reply to address is passed to the SendAysnc method but was not applied to the MimeMessage generated. This should be a non breaking change where if no ReplyTo address is supplied it is not added, while when a ReplyTo message is supplied it is added in the email header appropriately.

I tried making some unit tests but couldn't without adding a lot of extra code or packages.
