### PR TITLE
[Docs] Adds possible implementation of invocable class to documentation

### DIFF
--- a/DocsV2/docs/Scheduler/README.md
+++ b/DocsV2/docs/Scheduler/README.md
@@ -64,6 +64,31 @@ scheduler
 
 What a simple, terse and expressive syntax! Easy Peasy!
 
+For completeness here is the possible impelmentation of the `GrabDataFromApiAndPutInDBInvocable` class:
+
+```csharp
+public class GrabDataFromApiAndPutInDBInvocable: IInvocable
+{
+    private readonly DbContext _dbContext;
+    public GrabDataFromApiAndPutInDBInvocable(DbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+    public Task Invoke()
+    {
+        //call api and save data to db
+        //...
+        _dbContext.SaveChangesAsync();
+    }
+}
+```
+
+Make sure that your invocable *itself* is available in the service container:
+
+```csharp
+services.AddTransient<GrabDataFromApiAndPutInDBInvocable>();
+```
+
 :::tip Cancel Long-Running Invocables
 Make your long-running invocable classes implement `Coravel.Invocable.ICancellableInvocable` to enable it to gracefully abort on application shutdown.
 


### PR DESCRIPTION
Reasoning behind this change is to provide working example of invocable class.

The "closest" one in the docs is few lines below (invocable with params), where is "do not register them with the DI services.". Which is directly opposing the necessity with "normal" invokable.

For the better explanation user have to navigate to Invocables page.

This update keeps the full working example  in one place. 

  
