### PR TITLE
Add ability to set Sender for mail

### DIFF
--- a/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/Coravel.Cache.Database.Core.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/Coravel.Cache.Database.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Coravel.Cache.Database.Core</PackageId>
     <Version>2.0.2</Version>
     <Authors>James Hickey</Authors>
@@ -19,9 +19,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Coravel" Version="3.0.0" />
-    <PackageReference Include="Dapper" Version="1.60.6" />
+    <PackageReference Include="Dapper" Version="2.1.28" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Coravel\Coravel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/Extensions.cs
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/Extensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 
 namespace Coravel.Cache.Database.Core

--- a/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/IDriver.cs
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.Database.Core/IDriver.cs
@@ -1,5 +1,4 @@
 using System.Data.Common;
-using System.Data.SqlClient;
 
 namespace Coravel.Cache.Database.Core
 {

--- a/Src/Coravel.Cache.Database/Coravel.Cache.PostgreSQL/Coravel.Cache.PostgreSQL.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.PostgreSQL/Coravel.Cache.PostgreSQL.csproj
@@ -2,11 +2,14 @@
 
   <ItemGroup>
     <PackageReference Include="npgsql" Version="4.0.7" />
-    <PackageReference Include="Coravel.Cache.Database.Core" version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Coravel.Cache.Database.Core\Coravel.Cache.Database.Core.csproj" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Coravel.Cache.PostgreSQL</PackageId>
     <Version>2.0.2</Version>
     <Authors>James Hickey</Authors>

--- a/Src/Coravel.Cache.Database/Coravel.Cache.SqlServer/Coravel.Cache.SqlServer.csproj
+++ b/Src/Coravel.Cache.Database/Coravel.Cache.SqlServer/Coravel.Cache.SqlServer.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <PackageReference Include="Coravel.Cache.Database.Core" version="2.0.0" />
-  </ItemGroup>
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Coravel.Cache.SQLServer</PackageId>
     <Version>2.0.2</Version>
     <Authors>James Hickey</Authors>
@@ -21,5 +17,13 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Coravel.Cache.Database.Core\Coravel.Cache.Database.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Src/Coravel.Mailer/Mail/Interfaces/IMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Interfaces/IMailer.cs
@@ -7,6 +7,6 @@ namespace Coravel.Mailer.Mail.Interfaces
     {
         Task<string> RenderAsync<T>(Mailable<T> mailable);
         Task SendAsync<T>(Mailable<T> mailable);
-        Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments = null);
+        Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments = null);
     }
 }

--- a/Src/Coravel.Mailer/Mail/Mailable.cs
+++ b/Src/Coravel.Mailer/Mail/Mailable.cs
@@ -18,6 +18,11 @@ namespace Coravel.Mailer.Mail
         private MailRecipient _from;
 
         /// <summary>
+        /// Who is sending the email on the from address's behalf.
+        /// </summary>
+        private MailRecipient? _sender;
+
+        /// <summary>
         /// Recipients of the message.
         /// </summary>
         private IEnumerable<MailRecipient> _to;
@@ -63,6 +68,18 @@ namespace Coravel.Mailer.Mail
         /// View data to pass to the view to render.
         /// </summary>
         private T _viewModel;
+
+        public Mailable<T> Sender(MailRecipient recipient)
+        {
+            this._sender = recipient;
+            return this;
+        }
+
+        public Mailable<T> Sender(string email) =>
+            this.Sender(new MailRecipient(email));
+
+        public Mailable<T> Sender(string email, string name) =>
+            this.Sender(new MailRecipient(email, name));
 
         public Mailable<T> From(MailRecipient recipient)
         {
@@ -173,6 +190,7 @@ namespace Coravel.Mailer.Mail
                 this._to,
                 this._from,
                 this._replyTo,
+                this._sender,
                 this._cc,
                 this._bcc,
                 this._attachments

--- a/Src/Coravel.Mailer/Mail/Mailers/AssertMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/AssertMailer.cs
@@ -14,6 +14,7 @@ namespace Coravel.Mailer.Mail.Mailers
             public IEnumerable<MailRecipient> to { get; set; }
             public MailRecipient from { get; set; }
             public MailRecipient replyTo { get; set; }
+            public MailRecipient sender { get; set; }
             public IEnumerable<MailRecipient> cc { get; set; }
             public IEnumerable<MailRecipient> bcc { get; set; }
             public IEnumerable<Attachment> attachments { get; set; }
@@ -26,7 +27,7 @@ namespace Coravel.Mailer.Mail.Mailers
             this._assertAction = assertAction;
         }
 
-        public Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
+        public Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
         {
             this._assertAction(new Data
             {
@@ -35,6 +36,7 @@ namespace Coravel.Mailer.Mail.Mailers
                 to = to,
                 from = from,
                 replyTo = replyTo,
+                sender = sender,
                 cc = cc,
                 bcc = bcc,
                 attachments = attachments

--- a/Src/Coravel.Mailer/Mail/Mailers/CustomMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/CustomMailer.cs
@@ -7,7 +7,7 @@ namespace Coravel.Mailer.Mail.Mailers
 {
     public class CustomMailer : IMailer
     {
-        public delegate Task SendAsyncFunc(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments = null);
+        public delegate Task SendAsyncFunc(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments = null);
         private RazorRenderer _renderer;
         private SendAsyncFunc _sendAsyncFunc;
         private MailRecipient _globalFrom;
@@ -25,10 +25,10 @@ namespace Coravel.Mailer.Mail.Mailers
         public async Task SendAsync<T>(Mailable<T> mailable) =>
             await mailable.SendAsync(this._renderer, this);
 
-        public async Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
+        public async Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
         {
             await this._sendAsyncFunc(
-                message, subject, to, this._globalFrom ?? from, replyTo, cc, bcc, attachments
+                message, subject, to, this._globalFrom ?? from, replyTo, sender, cc, bcc, attachments
             );
         }
     }

--- a/Src/Coravel.Mailer/Mail/Mailers/FileLogMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/FileLogMailer.cs
@@ -27,7 +27,7 @@ namespace Coravel.Mailer.Mail.Mailers
             return await mailable.RenderAsync(this._renderer, this);
         }
 
-        public async Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments = null)
+        public async Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments = null)
         {
             from = this._globalFrom ?? from;
 
@@ -39,6 +39,7 @@ Subject: {subject}
 To: {CommaSeparated(to)}    
 From: {DisplayAddress(from)}
 ReplyTo: {DisplayAddress(replyTo)}
+Sender: {DisplayAddress(sender)}
 Cc: {CommaSeparated(cc)}
 Bcc: {CommaSeparated(bcc)}
 Attachment: { (attachments is null ? "N/A" : string.Join(";", attachments.Select(a => a.Name))) }

--- a/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
@@ -126,7 +126,7 @@ namespace Coravel.Mailer.Mail.Mailers
 
         private void SetFrom(MailRecipient @from, MimeMessage mail)
         {
-            mail.From.Add(AsMailboxAddress(this._globalFrom ?? @from));
+            mail.From.Add(AsMailboxAddress(@from ?? this._globalFrom));
         }
 
         private static void SetReplyTo(MailRecipient replyTo, MimeMessage mail)

--- a/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
@@ -50,7 +50,7 @@ namespace Coravel.Mailer.Mail.Mailers
             await mailable.SendAsync(this._renderer, this);
         }
 
-        public async Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments = null)
+        public async Task SendAsync(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments = null)
         {
             var mail = new MimeMessage();
             
@@ -64,6 +64,11 @@ namespace Coravel.Mailer.Mail.Mailers
             if (replyTo != null)
             {
                 SetReplyTo(replyTo, mail);
+            }
+
+            if (sender != null)
+            {
+                SetSender(sender, mail);
             }
 
             using (var client = new SmtpClient())
@@ -127,6 +132,11 @@ namespace Coravel.Mailer.Mail.Mailers
         private static void SetReplyTo(MailRecipient replyTo, MimeMessage mail)
         {
             mail.ReplyTo.Add(AsMailboxAddress(replyTo));
+        }
+
+        private static void SetSender(MailRecipient sender, MimeMessage mail)
+        {
+            mail.Sender = AsMailboxAddress(sender);
         }
 
         private static MailboxAddress AsMailboxAddress(MailRecipient recipient) =>

--- a/Src/Coravel/Coravel.csproj
+++ b/Src/Coravel/Coravel.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>.net6.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Coravel</PackageId>
     <Version>5.0.2</Version>
     <Authors>James Hickey</Authors>

--- a/Src/Coravel/Scheduling/Schedule/EnsureContinuousSecondTicks.cs
+++ b/Src/Coravel/Scheduling/Schedule/EnsureContinuousSecondTicks.cs
@@ -3,44 +3,46 @@ using System.Collections.Generic;
 using System.Linq;
 using Coravel.Scheduling.Schedule.Helpers;
 
-namespace Coravel.Scheduling.Schedule;
-
-public class EnsureContinuousSecondTicks
+namespace Coravel.Scheduling.Schedule
 {
-    private DateTime previousTick;
 
-    public EnsureContinuousSecondTicks(DateTime firstTick)
+    public class EnsureContinuousSecondTicks
     {
-        previousTick = firstTick;
-    }
+        private DateTime previousTick;
 
-    /// <summary>
-    /// Give this method when the next tick occurs and it will return any intermediary ticks that should
-    /// have existed been the stored previous tick and the next one.
-    /// </summary>
-    /// <param name="nextTick"></param>
-    /// <returns></returns>
-    public IEnumerable<DateTime> GetTicksBetweenPreviousAndNext(DateTime nextTick)
-    {
-        // Starting at previousTick, we move ahead one second a time and record the next time until we get to the "nextTick".
-        // Then we check if there are any missed ticks between the two.
-        List<DateTime> missingTicks = null; // We don't want to commit any memory until we know for sure there's at least 1 missed tick.
-        DateTime nextTickToTest = previousTick.PreciseUpToSecond().AddSeconds(1);
-        while (nextTickToTest < nextTick.PreciseUpToSecond())
+        public EnsureContinuousSecondTicks(DateTime firstTick)
         {
-            if (missingTicks is null)
-            {
-                missingTicks = new List<DateTime>();
-            }
-            missingTicks.Add(nextTickToTest);
-            nextTickToTest = nextTickToTest.PreciseUpToSecond().AddSeconds(1);
+            previousTick = firstTick;
         }
 
-        return missingTicks ?? Enumerable.Empty<DateTime>();
-    }
+        /// <summary>
+        /// Give this method when the next tick occurs and it will return any intermediary ticks that should
+        /// have existed been the stored previous tick and the next one.
+        /// </summary>
+        /// <param name="nextTick"></param>
+        /// <returns></returns>
+        public IEnumerable<DateTime> GetTicksBetweenPreviousAndNext(DateTime nextTick)
+        {
+            // Starting at previousTick, we move ahead one second a time and record the next time until we get to the "nextTick".
+            // Then we check if there are any missed ticks between the two.
+            List<DateTime> missingTicks = null; // We don't want to commit any memory until we know for sure there's at least 1 missed tick.
+            DateTime nextTickToTest = previousTick.PreciseUpToSecond().AddSeconds(1);
+            while (nextTickToTest < nextTick.PreciseUpToSecond())
+            {
+                if (missingTicks is null)
+                {
+                    missingTicks = new List<DateTime>();
+                }
+                missingTicks.Add(nextTickToTest);
+                nextTickToTest = nextTickToTest.PreciseUpToSecond().AddSeconds(1);
+            }
 
-    public void SetNextTick(DateTime nextTick)
-    {
-        previousTick = nextTick;
+            return missingTicks ?? Enumerable.Empty<DateTime>();
+        }
+
+        public void SetNextTick(DateTime nextTick)
+        {
+            previousTick = nextTick;
+        }
     }
 }

--- a/Src/Coravel/Scheduling/Schedule/Event/ScheduledEvent.cs
+++ b/Src/Coravel/Scheduling/Schedule/Event/ScheduledEvent.cs
@@ -108,7 +108,7 @@ namespace Coravel.Scheduling.Schedule.Event
             }
             else
             {
-                await using AsyncServiceScope scope = new(this._scopeFactory.CreateAsyncScope());
+                await using AsyncServiceScope scope = new AsyncServiceScope(this._scopeFactory.CreateAsyncScope());
                 if (GetInvocable(scope.ServiceProvider) is IInvocable invocable)
                 {
                     if (invocable is ICancellableInvocable cancellableInvokable)

--- a/Src/UnitTests/MailerUnitTests/Mail/CustomMailerTests.cs
+++ b/Src/UnitTests/MailerUnitTests/Mail/CustomMailerTests.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Mail
         [Fact]
         public async Task CustomMailerSucessful()
         {
-            async Task SendMailCustom(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
+            async Task SendMailCustom(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
             {
                 Assert.Equal("test", subject);
                 Assert.Equal("from@test.com", from.Email);
@@ -41,7 +41,7 @@ namespace UnitTests.Mail
         [Fact]
         public async Task CustomMailer_GlobalFrom()
         {
-            async Task SendMailCustom(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
+            async Task SendMailCustom(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
             {
                 Assert.Equal("global@test.com", from.Email);
                 Assert.Equal("Global", from.Name);
@@ -66,7 +66,7 @@ namespace UnitTests.Mail
         [Fact]
         public async Task CustomMailer_Render()
         {
-            async Task SendMailCustom(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
+            async Task SendMailCustom(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
             {
                 await Task.CompletedTask;
             };
@@ -92,7 +92,7 @@ namespace UnitTests.Mail
         [Fact]
         public async Task CustomMailerHasAttachments()
         {
-            async Task SendMailCustom(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
+            async Task SendMailCustom(string message, string subject, IEnumerable<MailRecipient> to, MailRecipient from, MailRecipient replyTo, MailRecipient sender, IEnumerable<MailRecipient> cc, IEnumerable<MailRecipient> bcc, IEnumerable<Attachment> attachments)
             {
                 Assert.Equal(2, attachments.Count());
                 Assert.Equal("Attachment 2", attachments.Skip(1).Single().Name);


### PR DESCRIPTION
Consolidated target frameworks for libraries and referenced local projects over public packages.

Added a `Sender(...)` method to be able to set the Sender property of the MailMessage. #374 
Have From() override default global From. #321 