### PR TITLE
Add support for inline attachments in SmtpMailer

### DIFF
--- a/Src/Coravel.Mailer/Mail/Attachment.cs
+++ b/Src/Coravel.Mailer/Mail/Attachment.cs
@@ -4,5 +4,6 @@ namespace Coravel.Mailer.Mail
     {
         public byte[] Bytes { get; set; }
         public string Name { get; set; }
+        public string ContentId { get; set; }
     }
 }

--- a/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
+++ b/Src/Coravel.Mailer/Mail/Mailers/SmtpMailer.cs
@@ -89,7 +89,16 @@ namespace Coravel.Mailer.Mail.Mailers
             {
                 foreach (var attachment in attachments)
                 {
-                    bodyBuilder.Attachments.Add(attachment.Name, attachment.Bytes);
+                    if (string.IsNullOrWhiteSpace(attachment.ContentId) == false)
+                    {
+                        var image = bodyBuilder.LinkedResources.Add(attachment.Name, attachment.Bytes);
+                        // We do this instead of using their value because RFC states the Content-Id value MUST be in the message id format.
+                        image.ContentId = MimeKit.Utils.MimeUtils.GenerateMessageId();
+                        // Now replace where they applied it in the html template with the updated correct version
+                        bodyBuilder.HtmlBody = bodyBuilder.HtmlBody.Replace($"\"cid:{attachment.ContentId}\"", $"\"cid:{image.ContentId}\"", System.StringComparison.OrdinalIgnoreCase);
+                    }
+                    else
+                        bodyBuilder.Attachments.Add(attachment.Name, attachment.Bytes);
                 }
             }
 


### PR DESCRIPTION
Enhanced the `Attachment` class by adding a `ContentId` property to support inline content. Updated `SmtpMailer` to handle attachments with non-empty `ContentId` as linked resources, generating RFC-compliant `ContentId` using `MimeKit.Utils.MimeUtils.GenerateMessageId()`. Modified the HTML body to reference the correct `ContentId`. Attachments with empty or whitespace `ContentId` are added as regular attachments.

Thank you for your contribution!
Before submitting this PR, please consider:

- If you are fixing something **other than a typo, please always create an issue first**. Otherwise, your PR will probably be rejected.
- You have added unit tests which (a) pass and (b) sufficiently cover your changes

Based on feature request #376