### PR TITLE
Fix race condition in RunOnceAtStart logic

### DIFF
--- a/Src/Coravel/Coravel.csproj
+++ b/Src/Coravel/Coravel.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>.net6.0</TargetFramework>
     <PackageId>Coravel</PackageId>
-    <Version>6.0.1</Version>
+    <Version>6.0.2</Version>
     <Authors>James Hickey</Authors>
     <Company>-</Company>
     <Title>Coravel</Title>

--- a/Src/UnitTests/CoravelUnitTests/Scheduling/IntervalTests/SchedulerRunAtStartTests.cs
+++ b/Src/UnitTests/CoravelUnitTests/Scheduling/IntervalTests/SchedulerRunAtStartTests.cs
@@ -76,14 +76,14 @@ namespace CoravelUnitTests.Scheduling.IntervalTests
         }
 
         /// <summary>
-        /// This test runs for a long time - like 40 seconds on a fast codespaces VM. But, that's how many iterations of running this test takes to
-        /// catch a really rare race condition. This was causing the `RunOnceAtStart` method to have an bug where intermittently those tasks weren't running
+        /// This test runs for a long time. But, that's how many iterations of running this test takes to
+        /// catch a rare race condition. This was causing the `RunOnceAtStart` method to have an bug where intermittently those tasks weren't running
         /// when the application started up.
         /// </summary>
         [Fact]
         public async Task TestConcurrentThreadsDoesNotSkipForcedRun()
         {
-            for(int i = 0; i < 10000; i++)
+            for(int i = 0; i < 20000; i++)
             {
                 var scheduler = new Scheduler(new InMemoryMutex(), new ServiceScopeFactoryStub(), new DispatcherStub());
                 var taskRan = false;


### PR DESCRIPTION
Fixes a bug where a race condition would intermittently cause a scheduled task marked to run immediately when the application starts to not run at all.
